### PR TITLE
correction for Tensorflow 2.1 and Keras 2.3.1

### DIFF
--- a/keras_lr_multiplier/multiplier.py
+++ b/keras_lr_multiplier/multiplier.py
@@ -77,7 +77,7 @@ class LRMultiplier(optimizers.Optimizer):
                 self.updates += self.optimizer.get_updates(loss, params)
             print(self.multipliers, i, self.optimizer.weights)
             for w in self.optimizer.weights:
-                if w not in self.weights:
+                if w.name not in [x.name for x in self.weights]:
                     self.weights.append(w)
         setattr(self, self.lr_attr, origin_lr)
 


### PR DESCRIPTION
Correction of the error equal can't be applied between int64 and float